### PR TITLE
Fix syntax of the example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ module.exports = function(config) {
     // To be able to record the paint times accurately 
     client: {
       useIframe: false
-    }
+    },
 
     // Each test case represents a rendering metric.
     // The Junit reporter can be used to see times of individual metrics


### PR DESCRIPTION
I tried copy & pasting the config from the README and karma choked on it as being malformed. The problem is a missing comma after one of the configuration fields.